### PR TITLE
Village spawn yaw + Village warps

### DIFF
--- a/src/main/java/com/johnymuffin/jvillage/beta/JVUtility.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/JVUtility.java
@@ -74,19 +74,19 @@ public class JVUtility {
     }
 
     public static int closestYaw(double yaw){
-        if(yaw < 0) yaw = 360 + yaw;
+        if (yaw < 0) yaw = 360 + yaw;
         Set<Integer> yaws = new HashSet<>(Arrays.asList(0, 90, 180, 270, 360));
         int closest = -1;
         double lowestDiff = Integer.MAX_VALUE;
 
-        for(Integer entry : yaws){
+        for (Integer entry : yaws) {
             double diff = Math.abs(yaw - entry);
-            if(diff < lowestDiff){
+            if (diff < lowestDiff) {
                 closest = entry;
                 lowestDiff = diff;
             }
         }
-        if(closest == 360) return 0;
+        if (closest == 360) return 0;
         return closest;
     }
 

--- a/src/main/java/com/johnymuffin/jvillage/beta/JVUtility.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/JVUtility.java
@@ -14,6 +14,7 @@ import org.bukkit.entity.Player;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -70,6 +71,23 @@ public class JVUtility {
         BigDecimal bd = BigDecimal.valueOf(value);
         bd = bd.setScale(places, RoundingMode.HALF_UP);
         return bd.doubleValue();
+    }
+
+    public static int closestYaw(double yaw){
+        if(yaw < 0) yaw = 360 + yaw;
+        Set<Integer> yaws = new HashSet<>(Arrays.asList(0, 90, 180, 270, 360));
+        int closest = -1;
+        double lowestDiff = Integer.MAX_VALUE;
+
+        for(Integer entry : yaws){
+            double diff = Math.abs(yaw - entry);
+            if(diff < lowestDiff){
+                closest = entry;
+                lowestDiff = diff;
+            }
+        }
+        if(closest == 360) return 0;
+        return closest;
     }
 
     public static String formatVillageList(Village[] villages) {

--- a/src/main/java/com/johnymuffin/jvillage/beta/JVillage.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/JVillage.java
@@ -16,6 +16,7 @@ import com.johnymuffin.jvillage.beta.listeners.JVPlayerMoveListener;
 import com.johnymuffin.jvillage.beta.maps.JPlayerMap;
 import com.johnymuffin.jvillage.beta.maps.JVillageMap;
 import com.johnymuffin.jvillage.beta.models.VCords;
+import com.johnymuffin.jvillage.beta.models.VSpawnCords;
 import com.johnymuffin.jvillage.beta.models.Village;
 import com.johnymuffin.jvillage.beta.models.chunk.VChunk;
 import com.johnymuffin.jvillage.beta.models.chunk.VClaim;
@@ -584,13 +585,13 @@ public class JVillage extends JavaPlugin implements ClaimManager, PoseidonCustom
             }
 
             //Misc
-            VCords townSpawn = null;
+            VSpawnCords townSpawn = null;
             try {
-                townSpawn = new VCords(town.getSpawn().getBlockX(), town.getSpawn().getBlockY(), town.getSpawn().getBlockZ(), town.getSpawn().getWorld().getName());
+                townSpawn = new VSpawnCords(town.getSpawn().getBlockX(), town.getSpawn().getBlockY(), town.getSpawn().getBlockZ(), 0, town.getSpawn().getWorld().getName());
             } catch (Exception exception) {
                 log.warning("[" + pluginName + "] Could not find town spawn for town " + newTownName + ". World spawn will be used instead.");
                 logger(Level.WARNING, "Could not find town spawn for town " + newTownName + ". The town spawn will be set to the world spawn.");
-                townSpawn = new VCords(Bukkit.getWorlds().get(0).getSpawnLocation().getBlockX(), Bukkit.getWorlds().get(0).getSpawnLocation().getBlockY(), Bukkit.getWorlds().get(0).getSpawnLocation().getBlockZ(), Bukkit.getWorlds().get(0).getName());
+                townSpawn = new VSpawnCords(Bukkit.getWorlds().get(0).getSpawnLocation().getBlockX(), Bukkit.getWorlds().get(0).getSpawnLocation().getBlockY(), Bukkit.getWorlds().get(0).getSpawnLocation().getBlockZ(), 0, Bukkit.getWorlds().get(0).getName());
             }
 
             //First chunk from townSpawn
@@ -801,15 +802,15 @@ public class JVillage extends JavaPlugin implements ClaimManager, PoseidonCustom
 
             //Faction Spawn
             Location factionSpawn = faction.getHome();
-            VCords villageSpawn = null;
+            VSpawnCords villageSpawn = null;
             VChunk spawnChunk = null;
             if(factionSpawn == null) {
                 log.warning("[" + pluginName + "] Faction " + newVillageName + " has no spawn. The world spawn will be used instead.");
                 spawnChunk = new VChunk(Bukkit.getWorlds().get(0).getSpawnLocation());
-                villageSpawn = new VCords(Bukkit.getWorlds().get(0).getSpawnLocation());
+                villageSpawn = new VSpawnCords(Bukkit.getWorlds().get(0).getSpawnLocation());
             } else {
                 spawnChunk = new VChunk(factionSpawn);
-                villageSpawn = new VCords(factionSpawn);
+                villageSpawn = new VSpawnCords(factionSpawn);
             }
 
 
@@ -902,7 +903,7 @@ public class JVillage extends JavaPlugin implements ClaimManager, PoseidonCustom
         return this.playerData;
     }
 
-    public Village generateNewVillage(String townName, UUID owner, VChunk vChunk, VCords townSpawn) {
+    public Village generateNewVillage(String townName, UUID owner, VChunk vChunk, VSpawnCords townSpawn) {
         if (!villageNameAvailable(townName)) {
             return null;
         }

--- a/src/main/java/com/johnymuffin/jvillage/beta/commands/JVillageCMD.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/commands/JVillageCMD.java
@@ -38,6 +38,9 @@ public class JVillageCMD extends JVBaseCommand {
         registerCommand(new JDemoteCommand(plugin), "demote");
         registerCommand(new JPromoteCommand(plugin), "promote");
         registerCommand(new JSetSpawnCommand(plugin), "setspawn");
+        registerCommand(new JWarpCommand(plugin), "warp");
+        registerCommand(new JSetWarpCommand(plugin), "setwarp");
+        registerCommand(new JDelWarpCommand(plugin), "delwarp");
         registerCommand(new JRenameCommand(plugin), "rename");
         registerCommand(new JListCommand(plugin), "list");
         registerCommand(new JFlagCommand(plugin), "flag", "flags", "f");

--- a/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JCreateCommand.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JCreateCommand.java
@@ -60,13 +60,15 @@ public class JCreateCommand extends JVBaseCommand implements CommandExecutor {
 
         //If string doesn't only contain numbers and letters
         if (!villageName.matches("[a-zA-Z0-9]+")) {
-            commandSender.sendMessage(language.getMessage("command_village_create_invalid_name"));
+            commandSender.sendMessage(language.getMessage("command_village_create_invalid_name")
+                    .replace("%max%", settings.getConfigInteger("settings.town.max-name-length.value").toString()));
             return true;
         }
 
         //If string is too long
         if (villageName.length() > settings.getConfigInteger("settings.town.max-name-length.value")) {
-            commandSender.sendMessage(language.getMessage("command_village_create_invalid_name"));
+            commandSender.sendMessage(language.getMessage("command_village_create_invalid_name")
+                    .replace("%max%", settings.getConfigInteger("settings.town.max-name-length.value").toString()));
             return true;
         }
 

--- a/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JCreateCommand.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JCreateCommand.java
@@ -4,7 +4,7 @@ import com.johnymuffin.beta.fundamentals.api.EconomyAPI;
 import com.johnymuffin.beta.fundamentals.api.FundamentalsAPI;
 import com.johnymuffin.jvillage.beta.JVillage;
 import com.johnymuffin.jvillage.beta.commands.JVBaseCommand;
-import com.johnymuffin.jvillage.beta.models.VCords;
+import com.johnymuffin.jvillage.beta.models.VSpawnCords;
 import com.johnymuffin.jvillage.beta.models.Village;
 import com.johnymuffin.jvillage.beta.models.chunk.ChunkClaimSettings;
 import com.johnymuffin.jvillage.beta.models.chunk.VChunk;
@@ -127,7 +127,7 @@ public class JCreateCommand extends JVBaseCommand implements CommandExecutor {
             }
         }
 
-        Village newVillage = new Village(plugin, villageName, UUID.randomUUID(), player.getUniqueId(), vChunk, new VCords(player.getLocation()));
+        Village newVillage = new Village(plugin, villageName, UUID.randomUUID(), player.getUniqueId(), vChunk, new VSpawnCords(player.getLocation()));
         plugin.getVillageMap().addVillageToMap(newVillage);
 
         //Metadata for first chunk

--- a/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JDelWarpCommand.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JDelWarpCommand.java
@@ -1,32 +1,34 @@
 package com.johnymuffin.jvillage.beta.commands.village;
 
 import com.johnymuffin.jvillage.beta.JVillage;
-import com.johnymuffin.jvillage.beta.commands.JVBaseCommand;
-import com.johnymuffin.jvillage.beta.models.VSpawnCords;
-import com.johnymuffin.jvillage.beta.models.Village;
-import com.johnymuffin.jvillage.beta.models.chunk.VChunk;
 import com.johnymuffin.jvillage.beta.player.VPlayer;
+import com.johnymuffin.jvillage.beta.models.Village;
+import com.johnymuffin.jvillage.beta.commands.JVBaseCommand;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-public class JSetSpawnCommand extends JVBaseCommand implements CommandExecutor {
+public class JDelWarpCommand extends JVBaseCommand implements CommandExecutor {
 
-    public JSetSpawnCommand(JVillage plugin) {
+    public JDelWarpCommand(JVillage plugin) {
         super(plugin);
     }
 
     @Override
     public boolean onCommand(CommandSender commandSender, Command command, String s, String[] strings) {
-
-        if (!isAuthorized(commandSender, "jvillage.player.setspawn")) {
+        if (!isAuthorized(commandSender, "jvillage.player.delwarp")) {
             commandSender.sendMessage(language.getMessage("no_permission"));
             return true;
         }
 
         if (!(commandSender instanceof Player)) {
             commandSender.sendMessage(language.getMessage("unavailable_to_console"));
+            return true;
+        }
+
+        if (strings.length < 1) {
+            commandSender.sendMessage(language.getMessage("command_village_delwarp_use"));
             return true;
         }
 
@@ -39,26 +41,26 @@ public class JSetSpawnCommand extends JVBaseCommand implements CommandExecutor {
             return true;
         }
 
-        if (!village.getOwner().equals(player.getUniqueId())) {
-            String message = language.getMessage("command_village_setspawn_not_owner");
+        if (!village.isOwner(vPlayer.getUUID()) && !village.isAssistant(vPlayer.getUUID())) {
+            String message = language.getMessage("command_village_delwarp_no_permission");
             message = message.replace("%village%", village.getTownName());
             commandSender.sendMessage(message);
             return true;
         }
 
-        VChunk vChunk = new VChunk(player.getLocation());
-        if (!village.getClaims().contains(vChunk)) {
-            String message = language.getMessage("command_village_setspawn_not_in_village");
-            message = message.replace("%village%", village.getTownName());
-            commandSender.sendMessage(message);
+        String warpName = strings[0];
+
+        if (!village.getWarps().containsKey(warpName)) {
+            commandSender.sendMessage(language.getMessage("command_village_delwarp_not_found")
+                    .replace("%warp%", warpName)
+                    .replace("%village%", village.getTownName()));
             return true;
         }
 
-        VSpawnCords cords = new VSpawnCords(player.getLocation());
-        village.setTownSpawn(cords);
-        village.broadcastToTown(language.getMessage("command_village_setspawn_set_broadcast")
+        village.removeWarp(warpName);
+        village.broadcastToTown(language.getMessage("command_village_delwarp_del_broadcast")
                 .replace("%player%", player.getName())
-                .replace("%cords%", cords.toString())
+                .replace("%warp%", warpName)
         );
 
         return true;

--- a/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JKickCommand.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JKickCommand.java
@@ -74,7 +74,9 @@ public class JKickCommand extends JVBaseCommand implements CommandExecutor {
             target.setSelectedVillage(null);
         }
         village.removeMember(uuid);
-        commandSender.sendMessage(language.getMessage("command_village_kick_success"));
+        commandSender.sendMessage(language.getMessage("command_village_kick_success")
+                .replace("%player%", target.getUsername())
+                .replace("%village%", village.getTownName()));
 
         //Message the player if they are online
         Player targetPlayer = getPlayerFromUUID(uuid);

--- a/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JRenameCommand.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JRenameCommand.java
@@ -52,12 +52,14 @@ public class JRenameCommand extends JVBaseCommand implements CommandExecutor {
         String villageName = strings[0];
 
         if (!villageName.matches("[a-zA-Z0-9]+")) {
-            commandSender.sendMessage(language.getMessage("command_village_rename_invalid_name"));
+            commandSender.sendMessage(language.getMessage("command_village_rename_invalid_name")
+                    .replace("%max%", settings.getConfigInteger("settings.town.max-name-length.value").toString()));
             return true;
         }
 
         if (villageName.length() > settings.getConfigInteger("settings.town.max-name-length.value")) {
-            commandSender.sendMessage(language.getMessage("command_village_rename_invalid_name"));
+            commandSender.sendMessage(language.getMessage("command_village_rename_invalid_name")
+                    .replace("%max%", settings.getConfigInteger("settings.town.max-name-length.value").toString()));
             return true;
         }
 

--- a/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JSetSpawnCommand.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JSetSpawnCommand.java
@@ -2,7 +2,7 @@ package com.johnymuffin.jvillage.beta.commands.village;
 
 import com.johnymuffin.jvillage.beta.JVillage;
 import com.johnymuffin.jvillage.beta.commands.JVBaseCommand;
-import com.johnymuffin.jvillage.beta.models.VCords;
+import com.johnymuffin.jvillage.beta.models.VSpawnCords;
 import com.johnymuffin.jvillage.beta.models.Village;
 import com.johnymuffin.jvillage.beta.models.chunk.VChunk;
 import com.johnymuffin.jvillage.beta.player.VPlayer;
@@ -49,7 +49,7 @@ public class JSetSpawnCommand extends JVBaseCommand implements CommandExecutor {
             return true;
         }
 
-        VCords cords = new VCords(player.getLocation());
+        VSpawnCords cords = new VSpawnCords(player.getLocation());
         village.setTownSpawn(cords);
         village.broadcastToTown(player.getDisplayName() + " has set the spawn point to " + cords.toString());
         return true;

--- a/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JSetWarpCommand.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JSetWarpCommand.java
@@ -1,0 +1,109 @@
+package com.johnymuffin.jvillage.beta.commands.village;
+
+import com.johnymuffin.beta.fundamentals.api.EconomyAPI;
+import com.johnymuffin.beta.fundamentals.api.FundamentalsAPI;
+import com.johnymuffin.jvillage.beta.JVillage;
+import com.johnymuffin.jvillage.beta.commands.JVBaseCommand;
+import com.johnymuffin.jvillage.beta.models.VSpawnCords;
+import com.johnymuffin.jvillage.beta.models.Village;
+import com.johnymuffin.jvillage.beta.models.chunk.VChunk;
+import com.johnymuffin.jvillage.beta.player.VPlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class JSetWarpCommand extends JVBaseCommand implements CommandExecutor {
+
+    public JSetWarpCommand(JVillage plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender commandSender, Command command, String s, String[] strings) {
+        if (!isAuthorized(commandSender, "jvillage.player.setwarp")) {
+            commandSender.sendMessage(language.getMessage("no_permission"));
+            return true;
+        }
+
+        if (!(commandSender instanceof Player)) {
+            commandSender.sendMessage(language.getMessage("unavailable_to_console"));
+            return true;
+        }
+
+        if (strings.length < 1) {
+            commandSender.sendMessage(language.getMessage("command_village_setwarp_use"));
+            return true;
+        }
+
+        Player player = (Player) commandSender;
+        VPlayer vPlayer = plugin.getPlayerMap().getPlayer(player.getUniqueId());
+        Village village = vPlayer.getSelectedVillage();
+
+        if (village == null) {
+            commandSender.sendMessage(language.getMessage("no_village_selected"));
+            return true;
+        }
+
+        if (!village.isOwner(vPlayer.getUUID()) && !village.isAssistant(vPlayer.getUUID())) {
+            String message = language.getMessage("command_village_setwarp_no_permission");
+            message = message.replace("%village%", village.getTownName());
+            commandSender.sendMessage(message);
+            return true;
+        }
+
+        String warpName = strings[0];
+
+        if (!warpName.matches("[a-zA-Z0-9]+")) {
+            commandSender.sendMessage(language.getMessage("command_village_setwarp_invalid_name")
+                    .replace("%max%", settings.getConfigInteger("settings.warp.max-name-length.value").toString()));
+            return true;
+        }
+
+        if (warpName.length() > settings.getConfigInteger("settings.warp.max-name-length.value")) {
+            commandSender.sendMessage(language.getMessage("command_village_setwarp_invalid_name")
+                    .replace("%max%", settings.getConfigInteger("settings.warp.max-name-length.value").toString()));
+            return true;
+        }
+        
+        if (village.getWarps().containsKey(warpName)) {
+            commandSender.sendMessage(language.getMessage("command_village_setwarp_already_exists"));
+            return true;
+        }
+
+        VChunk vChunk = new VChunk(player.getLocation());
+        if (!village.getClaims().contains(vChunk)) {
+            String message = language.getMessage("command_village_setwarp_not_in_village");
+            message = message.replace("%village%", village.getTownName());
+            commandSender.sendMessage(message);
+            return true;
+        }
+
+        double creationCost = settings.getConfigDouble("settings.warp.price.amount");
+        if (creationCost > 0 && plugin.isFundamentalsEnabled()) {
+            EconomyAPI.EconomyResult result = FundamentalsAPI.getEconomy().subtractBalance(player.getUniqueId(), creationCost, player.getWorld().getName());
+            String message;
+            switch (result) {
+                case successful:
+                    commandSender.sendMessage(language.getMessage("command_village_setwarp_payment")
+                            .replace("%amount%", settings.getConfigDouble("settings.warp.price.amount").toString())
+                            .replace("%warp%", warpName));
+                    break;
+                case notEnoughFunds:
+                    commandSender.sendMessage(language.getMessage("command_village_setwarp_insufficient_funds")
+                            .replace("%cost%", String.valueOf(creationCost)));
+                    return true;
+                default:
+                    message = language.getMessage("unknown_economy_error");
+                    commandSender.sendMessage(message);
+                    return true;
+            }
+        }
+        VSpawnCords cords = new VSpawnCords(player.getLocation());
+        village.addWarp(warpName, cords);
+        village.broadcastToTown(language.getMessage("command_village_setwarp_set_broadcast")
+                .replace("%player%", player.getName())
+                .replace("%warp%", warpName));
+        return true;
+    }
+}

--- a/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JSpawnCommand.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JSpawnCommand.java
@@ -67,7 +67,7 @@ public class JSpawnCommand extends JVBaseCommand implements CommandExecutor {
             commandSender.sendMessage(message);
             return true;
         } catch (Exception e) {
-            String message = language.getMessage("command_village_spawm_unsafe");
+            String message = language.getMessage("command_village_spawn_unsafe");
             message = message.replace("%village%", village.getTownName());
             commandSender.sendMessage(message);
             return true;

--- a/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JWarpCommand.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JWarpCommand.java
@@ -1,0 +1,73 @@
+package com.johnymuffin.jvillage.beta.commands.village;
+
+import com.johnymuffin.jvillage.beta.JVillage;
+import com.johnymuffin.jvillage.beta.models.Village;
+import com.johnymuffin.jvillage.beta.player.VPlayer;
+import com.johnymuffin.jvillage.beta.commands.JVBaseCommand;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import static com.johnymuffin.jvillage.beta.JVUtility.getSafeDestination;
+
+public class JWarpCommand extends JVBaseCommand implements CommandExecutor {
+
+    public JWarpCommand(JVillage plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender commandSender, Command command, String s, String[] strings) {
+        if (!isAuthorized(commandSender, "jvillage.player.warp")) {
+            commandSender.sendMessage(language.getMessage("no_permission"));
+            return true;
+        }
+
+        if (!(commandSender instanceof Player)) {
+            commandSender.sendMessage(language.getMessage("unavailable_to_console"));
+            return true;
+        }
+
+        Player player = (Player) commandSender;
+        VPlayer vPlayer = plugin.getPlayerMap().getPlayer(player.getUniqueId());
+        Village village = vPlayer.getSelectedVillage();
+
+        if (village == null) {
+            commandSender.sendMessage(language.getMessage("no_village_selected"));
+            return true;
+        }
+
+        if (strings.length == 0) {
+            commandSender.sendMessage(language.getMessage("command_village_warp_list")
+                    .replace("%village%", village.getTownName()));
+            commandSender.sendMessage(ChatColor.GRAY + String.join(", ", village.getWarps().keySet()));
+            return true;
+        }
+
+        String warpName = strings[0];
+
+        if (!village.getWarps().containsKey(warpName)) {
+            commandSender.sendMessage(language.getMessage("command_village_warp_not_found")
+                    .replace("%warp%", warpName)
+                    .replace("%village%", village.getTownName()));
+            return true;
+        }
+
+        Location location = village.getWarps().get(warpName).getLocation();
+        try {
+            Location spawnLocation = getSafeDestination(location);
+            player.teleport(spawnLocation);
+            commandSender.sendMessage(language.getMessage("command_village_warp_success")
+                    .replace("%warp%", warpName));
+            return true;
+        } catch (Exception e) {
+            String message = language.getMessage("command_village_warp_unsafe");
+            message = message.replace("%warp%", warpName);
+            commandSender.sendMessage(message);
+            return true;
+        }
+    }
+}

--- a/src/main/java/com/johnymuffin/jvillage/beta/config/JVillageLanguage.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/config/JVillageLanguage.java
@@ -117,6 +117,7 @@ public class JVillageLanguage extends Configuration {
                 "\n&8- &7/village autoswitch [on/off] &8- &7Autoswitch town" +
                 "\n&8- &7/village balance [village] &8- &7Shows village balance" +
                 "\n&8- &7/village deposit [village] [amount] &8- &7Deposit money into village bank" +
+                "\n&8- &7/village warp [name] &8- &7Teleport to a village warp" +
                 "\n&8- &7/village spawn &8- &7Teleport to village spawn");
 
         map.put("command_village_assistant_help", "&cJVillage Assistant Commands" +
@@ -126,7 +127,9 @@ public class JVillageLanguage extends Configuration {
                 "\n&8- &7/village claim rectangle [chunk radius] &8- &7Claim a rectangle of chunks" +
                 "\n&8- &7/village claim auto &8- &7Claim chunks automatically as you walk (run again to disable)" +
                 "\n&8- &7/village withdraw [village] [amount] &8- &7Withdraw money from village bank" +
-                "\n&8- &7/village unclaim &8- &7Unclaim the chunk you are standing in");
+                "\n&8- &7/village unclaim &8- &7Unclaim the chunk you are standing in" +
+                "\n&8- &7/village setwarp [name] &8- &7Set a village warp" +
+                "\n&8- &7/village delwarp [name] &8- &7Delete a village warp");
 
         map.put("command_village_owner_help", "&cJVillage Owner Commands" +
                 "\n&8- &7/village create [name] &8- &7Create a new village" +
@@ -198,7 +201,7 @@ public class JVillageLanguage extends Configuration {
         map.put("command_village_delete_broadcast", "&bThe village &9%village% &bhas failed to maintain pace with the world and has fallen into ruin");
 
         map.put("command_village_create_use", "&cSorry, that is invalid. Try /village create [name]");
-        map.put("command_village_create_invalid_name", "&cSorry, that is an invalid name. Please only use letters and numbers and less then 16 characters");
+        map.put("command_village_create_invalid_name", "&cSorry, that is an invalid name. Please only use letters and numbers and less than %max% characters");
         map.put("command_village_create_already_exists", "&cSorry, that village name already exists");
         map.put("command_village_create_already_claimed", "&cSorry, that chunk is already claimed");
         map.put("command_village_create_success", "&bYou have created the village &9%village%");
@@ -242,7 +245,7 @@ public class JVillageLanguage extends Configuration {
         map.put("command_village_kick_denied", "&cSorry, you are not the owner of &9%village%&c so you can't kick members");
         map.put("command_village_kick_message", "&bYou have been kicked from &9%village%");
 
-        map.put("command_village_spawm_unsafe", "&cSorry, teleportation to %village% has been determined to be unsafe");
+        map.put("command_village_spawn_unsafe", "&cSorry, teleportation to %village% has been determined to be unsafe");
         map.put("command_village_spawn_success", "&bYou have been teleported to the spawn of &9%village%");
         map.put("command_village_spawn_not_member", "&cSorry, you are not a member of &9%village%&c so you can't teleport to the spawn");
 
@@ -254,7 +257,7 @@ public class JVillageLanguage extends Configuration {
 
         map.put("command_village_rename_use", "&cSorry, that is invalid. Try /village rename [name]");
         map.put("command_village_rename_not_owner", "&cSorry, you are not the owner of &9%village%&c so you can't change the name");
-        map.put("command_village_rename_invalid_name", "&cSorry, that is an invalid name. Please only use letters and numbers and less then 22 characters");
+        map.put("command_village_rename_invalid_name", "&cSorry, that is an invalid name. Please only use letters and numbers and less than %max% characters");
         map.put("command_village_rename_already_exists", "&cSorry, that village name already exists");
         map.put("command_village_rename_broadcast", "&bThe village &9%village% &bhas been renamed to &9%new_village%");
         map.put("command_village_rename_success", "&bYou have changed the name of &9%village%");
@@ -277,6 +280,27 @@ public class JVillageLanguage extends Configuration {
 
         map.put("command_village_setspawn_not_owner", "&cSorry, you are not the owner of &9%village%&c so you can't change the spawn");
         map.put("command_village_setspawn_not_in_village", "&cSorry, that location is not within an area claimed by &9%village%");
+        map.put("command_village_setspawn_set_broadcast", "&9%player% &bhas set the spawn point to &9%cords%");
+
+        map.put("command_village_setwarp_use", "&cSorry, that is invalid. Try /village setwarp [name]");
+        map.put("command_village_setwarp_no_permission", "&cSorry, you don't have permission to set warps in &9%village%");
+        map.put("command_village_setwarp_not_in_village", "&cSorry, that location is not within an area claimed by &9%village%");
+        map.put("command_village_setwarp_invalid_name", "&cSorry, that is an invalid name. Please only use letters and numbers and less than %max% characters");
+        map.put("command_village_setwarp_already_exists", "&cSorry, that warp name already exists");
+        map.put("command_village_setwarp_insufficient_funds", "&cSorry, you don't have enough money to set a warp. It costs $%cost%");
+        map.put("command_village_setwarp_payment", "&bYou have paid &9$%amount% &bto set the warp &9%warp%");
+        map.put("command_village_setwarp_set_broadcast", "&9%player% &bhas set the warp &9%warp%");
+
+
+        map.put("command_village_delwarp_use", "&cSorry, that is invalid. Try /village delwarp [name]");
+        map.put("command_village_delwarp_no_permission", "&cSorry, you don't have permission to delete warps in &9%village%");
+        map.put("command_village_delwarp_not_found", "&cSorry, the warp &9%warp% &cdoes not exist in &9%village%");
+        map.put("command_village_delwarp_del_broadcast", "&9%player% &bhas deleted the warp &9%warp%");
+        
+        map.put("command_village_warp_list", "&bWarp list of &9%village%:");
+        map.put("command_village_warp_success", "&bYou have been teleported to &9%warp%");
+        map.put("command_village_warp_unsafe", "&cSorry, teleportation to %warp% has been determined to be unsafe");
+        map.put("command_village_warp_not_found", "&cSorry, the warp &9%warp% &cdoes not exist in &9%village%");
 
         //Village Economy
 

--- a/src/main/java/com/johnymuffin/jvillage/beta/config/JVillageSettings.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/config/JVillageSettings.java
@@ -30,6 +30,12 @@ public class JVillageSettings extends Configuration {
         generateConfigOption("settings.town-claim-outpost.price.amount", 500);
         generateConfigOption("settings.town-claim-outpost.price.info", "This is the price to claim an outpost. Set to 0 to disable.");
 
+        generateConfigOption("settings.warp.price.amount", 500);
+        generateConfigOption("settings.warp.price.info", "This is the price to set a village warp. Set to 0 to disable.");
+        
+        generateConfigOption("settings.warp.max-name-length.value", 20);
+        generateConfigOption("settings.warp.max-name-length.info", "This is the maximum length of a town warp name.");
+        
         generateConfigOption("settings.resident.maximum-towns-owned.value", 10);
         generateConfigOption("settings.resident.maximum-towns-owned.info", "This is the maximum number of towns a resident can own. Set to 0 to disable.");
 

--- a/src/main/java/com/johnymuffin/jvillage/beta/models/VSpawnCords.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/models/VSpawnCords.java
@@ -1,0 +1,52 @@
+package com.johnymuffin.jvillage.beta.models;
+
+import com.johnymuffin.jvillage.beta.JVUtility;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.json.simple.JSONObject;
+
+public class VSpawnCords extends VCords{
+
+    private int yaw;
+
+    public VSpawnCords(int x, int y, int z, int yaw, String worldName){
+        super(x, y, z, worldName);
+        this.yaw = yaw;
+    }
+
+    public VSpawnCords(Location location){
+        this(location.getBlockX(), location.getBlockY(), location.getBlockZ(), JVUtility.closestYaw(location.getYaw()), location.getWorld().getName());
+    }
+
+    public VSpawnCords(JSONObject jsonObject){
+        super(Long.valueOf(String.valueOf(jsonObject.get("x"))).intValue(),
+                Long.valueOf(String.valueOf(jsonObject.get("y"))).intValue(),
+                Long.valueOf(String.valueOf(jsonObject.get("z"))).intValue(),
+                (String) jsonObject.get("world"));
+        if(jsonObject.get("yaw") == null){
+            yaw = 0;
+        }else{
+            yaw = Long.valueOf(String.valueOf(jsonObject.get("yaw"))).intValue();
+        }
+    }
+
+    @Override
+    public JSONObject getJsonObject(){
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("x", super.getX());
+        jsonObject.put("y", super.getY());
+        jsonObject.put("z", super.getZ());
+        jsonObject.put("yaw", yaw);
+        jsonObject.put("world", super.getWorldName());
+        return jsonObject;
+    }
+
+    public int getYaw(){
+        return yaw;
+    }
+
+    @Override
+    public Location getLocation() {
+        return new Location(Bukkit.getWorld(super.getWorldName()), super.getX(), super.getY(), super.getZ(), yaw, 0);
+    }
+}

--- a/src/main/java/com/johnymuffin/jvillage/beta/models/VSpawnCords.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/models/VSpawnCords.java
@@ -5,33 +5,33 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.json.simple.JSONObject;
 
-public class VSpawnCords extends VCords{
+public class VSpawnCords extends VCords {
 
     private int yaw;
 
-    public VSpawnCords(int x, int y, int z, int yaw, String worldName){
+    public VSpawnCords(int x, int y, int z, int yaw, String worldName) {
         super(x, y, z, worldName);
         this.yaw = yaw;
     }
 
-    public VSpawnCords(Location location){
+    public VSpawnCords(Location location) {
         this(location.getBlockX(), location.getBlockY(), location.getBlockZ(), JVUtility.closestYaw(location.getYaw()), location.getWorld().getName());
     }
 
-    public VSpawnCords(JSONObject jsonObject){
+    public VSpawnCords(JSONObject jsonObject) {
         super(Long.valueOf(String.valueOf(jsonObject.get("x"))).intValue(),
                 Long.valueOf(String.valueOf(jsonObject.get("y"))).intValue(),
                 Long.valueOf(String.valueOf(jsonObject.get("z"))).intValue(),
                 (String) jsonObject.get("world"));
-        if(jsonObject.get("yaw") == null){
+        if (jsonObject.get("yaw") == null) {
             yaw = 0;
-        }else{
+        } else {
             yaw = Long.valueOf(String.valueOf(jsonObject.get("yaw"))).intValue();
         }
     }
 
     @Override
-    public JSONObject getJsonObject(){
+    public JSONObject getJsonObject() {
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("x", super.getX());
         jsonObject.put("y", super.getY());
@@ -41,7 +41,7 @@ public class VSpawnCords extends VCords{
         return jsonObject;
     }
 
-    public int getYaw(){
+    public int getYaw() {
         return yaw;
     }
 

--- a/src/main/java/com/johnymuffin/jvillage/beta/models/Village.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/models/Village.java
@@ -13,6 +13,8 @@ import org.json.simple.JSONObject;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.TreeMap;
+import java.util.Map;
 import java.util.UUID;
 
 public class Village implements ClaimManager {
@@ -23,6 +25,7 @@ public class Village implements ClaimManager {
     private final ArrayList<UUID> assistants = new ArrayList<UUID>();
     private UUID owner;
     private VSpawnCords townSpawn;
+    private TreeMap<String, VSpawnCords> warps = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
     private boolean modified = false;
 
@@ -61,6 +64,13 @@ public class Village implements ClaimManager {
         this.townUUID = uuid; // Ignore UUID in JSON file and use the one from the file name
         this.owner = UUID.fromString(String.valueOf(object.get("owner")));
         this.townSpawn = new VSpawnCords((JSONObject) object.get("townSpawn"));
+        JSONObject warps = (JSONObject) object.get("warps");
+        for (Object warp : warps.keySet()) {
+            String warpName = warp.toString();
+            VSpawnCords cords = new VSpawnCords((JSONObject) warps.get(warpName));
+            this.warps.put(warpName, cords);
+        }
+
         JSONArray members = (JSONArray) object.get("members");
         for (Object member : members) {
             this.members.add(UUID.fromString(String.valueOf(member)));
@@ -214,6 +224,12 @@ public class Village implements ClaimManager {
         object.put("townSpawn", this.townSpawn.getJsonObject());
         object.put("creationTime", this.creationTime);
         object.put("balance", this.balance);
+
+        JSONObject warps = new JSONObject();
+        for (Map.Entry<String, VSpawnCords> entry : this.warps.entrySet()) {
+            warps.put(entry.getKey(), entry.getValue().getJsonObject());
+        }
+        object.put("warps", warps);
         return object;
     }
 
@@ -379,6 +395,20 @@ public class Village implements ClaimManager {
     public void setTownSpawn(VSpawnCords cords) {
         modified = true; // Indicate that the village has been modified and needs to be saved
         townSpawn = cords;
+    }
+
+    public TreeMap<String, VSpawnCords> getWarps() {
+        return this.warps;
+    }
+
+    public void addWarp(String name, VSpawnCords cords) {
+        modified = true;
+        warps.put(name, cords);
+    }
+
+    public void removeWarp(String name) {
+        modified = true;
+        warps.remove(name);
     }
 
     public boolean isMember(UUID uuid) {

--- a/src/main/java/com/johnymuffin/jvillage/beta/models/Village.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/models/Village.java
@@ -22,7 +22,7 @@ public class Village implements ClaimManager {
     private final ArrayList<UUID> members = new ArrayList<UUID>();
     private final ArrayList<UUID> assistants = new ArrayList<UUID>();
     private UUID owner;
-    private VCords townSpawn;
+    private VSpawnCords townSpawn;
 
     private boolean modified = false;
 
@@ -42,7 +42,7 @@ public class Village implements ClaimManager {
         }
     }
 
-    public Village(JVillage plugin, String townName, UUID townUUID, UUID owner, VChunk vChunk, VCords townSpawn) {
+    public Village(JVillage plugin, String townName, UUID townUUID, UUID owner, VChunk vChunk, VSpawnCords townSpawn) {
         this.plugin = plugin;
         this.townName = townName;
         this.townUUID = townUUID;
@@ -60,7 +60,7 @@ public class Village implements ClaimManager {
         this.townName = String.valueOf(object.get("name"));
         this.townUUID = uuid; // Ignore UUID in JSON file and use the one from the file name
         this.owner = UUID.fromString(String.valueOf(object.get("owner")));
-        this.townSpawn = new VCords((JSONObject) object.get("townSpawn"));
+        this.townSpawn = new VSpawnCords((JSONObject) object.get("townSpawn"));
         JSONArray members = (JSONArray) object.get("members");
         for (Object member : members) {
             this.members.add(UUID.fromString(String.valueOf(member)));
@@ -372,11 +372,11 @@ public class Village implements ClaimManager {
 //        return claims;
 //    }
 
-    public VCords getTownSpawn() {
+    public VSpawnCords getTownSpawn() {
         return townSpawn;
     }
 
-    public void setTownSpawn(VCords cords) {
+    public void setTownSpawn(VSpawnCords cords) {
         modified = true; // Indicate that the village has been modified and needs to be saved
         townSpawn = cords;
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -92,6 +92,7 @@ permissions:
       jvillage.player.promote: true
       jvillage.player.setowner: true
       jvillage.player.spawn: true
+      jvillage.player.warp: true
       jvillage.player.kick: true
       jvillage.player.unclaim: true
       jvillage.player.claim: true
@@ -125,6 +126,18 @@ permissions:
 
   jvillage.player.setspawn:
     description: Allows access to JVillage player setspawn commands
+    default: true
+
+  jvillage.player.warp:
+    description: Allows access to JVillage player warp command
+    default: true
+
+  jvillage.player.setwarp:
+    description: Allows access to JVillage player setwarp command
+    default: true
+
+  jvillage.player.delwarp:
+    description: Allows access to JVillage player delwarp command
     default: true
 
   jvillage.player.demote:


### PR DESCRIPTION
### Village spawn yaw
Right now, when running `/v setspawn`, the only direction that the village spawn can be set to is +Z.

I have altered the code so that when a player sets a village spawn, the yaw of the spawn (0 (+Z), 90 (-X), 180 (-Z) or 270 (+X)) is determined from their yaw.

Example: player runs `/v setspawn`, their current yaw is 100
the village spawn's yaw will be set to 90 (-X), since 100 is closest to 90

### Village warps
This feature allows village assistants to set village-specific warps which can then be used by all village members to quickly access prominent points in the village.

Commands:
`/v setwarp <name>` sets a new warp if a fee is paid
`/v delwarp <name>` deletes an existing warp

`/v warp` lists all warps in the selected village
`/v warp <name>` teleports to the specified warp in the village

Feature implemented by zavdav and SvGaming