### PR TITLE
implemented auto-unclaim functionality

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -36,7 +36,7 @@ jobs:
           mvn clean install
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: JVillage
           path: target/*.jar

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>groupId</groupId>
     <artifactId>JVillage</artifactId>
-    <version>1.0.13-SNAPSHOT</version>
+    <version>1.0.14-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/src/main/java/com/johnymuffin/jvillage/beta/JVillage.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/JVillage.java
@@ -24,6 +24,7 @@ import com.johnymuffin.jvillage.beta.routes.api.v1.JVillageGetPlayerRoute;
 import com.johnymuffin.jvillage.beta.routes.api.v1.JVillageGetVillageList;
 import com.johnymuffin.jvillage.beta.routes.api.v1.JVillageGetVillageRoute;
 import com.johnymuffin.jvillage.beta.tasks.AutoClaimingTask;
+import com.johnymuffin.jvillage.beta.tasks.AutoUnclaimingTask;
 import com.johnymuffin.jvillage.beta.tasks.AutomaticSaving;
 import com.johnymuffin.jvillage.beta.tasks.Metrics;
 import com.legacyminecraft.poseidon.event.PoseidonCustomListener;
@@ -210,6 +211,7 @@ public class JVillage extends JavaPlugin implements ClaimManager, PoseidonCustom
 
         //Run auto claim task
         Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, new AutoClaimingTask(plugin), 1, this.getSettings().getConfigInteger("settings.auto-claim.timer") * 20);
+        Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, new AutoUnclaimingTask(plugin), 1, this.getSettings().getConfigInteger("settings.auto-claim.timer") * 20);
         Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, new AutomaticSaving(plugin), 1, 20 * 60 * 10); //Save every 10 minutes
 
         //bstats metrics

--- a/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JClaimCommand.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JClaimCommand.java
@@ -72,6 +72,10 @@ public class JClaimCommand extends JVBaseCommand implements CommandExecutor {
                     message = message.replace("%village%", village.getTownName());
                     commandSender.sendMessage(message);
                 } else {
+                    // Disable autounclaim if it is enabled
+                    if (vPlayer.isAutoUnclaimingEnabled()) {
+                        vPlayer.setAutoUnclaimingEnabled(false, false);
+                    }
                     vPlayer.setAutoClaimingEnabled(true, false);
                     String message = language.getMessage("command_village_claim_autoclaim_on");
                     message = message.replace("%village%", village.getTownName());

--- a/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JUnclaimCommand.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JUnclaimCommand.java
@@ -52,6 +52,34 @@ public class JUnclaimCommand extends JVBaseCommand implements CommandExecutor {
             return true;
         }
 
+        //Auto unclaiming toggle
+        if (strings.length > 0 &&
+                (strings[0].equalsIgnoreCase("auto") || strings[0].equalsIgnoreCase("a") || strings[0].equalsIgnoreCase("ac") || strings[0].equalsIgnoreCase("autoclaim"))
+        ) {
+            if(!isAuthorized(commandSender, "jvillage.player.unclaim.auto")) {
+                commandSender.sendMessage(language.getMessage("no_permission"));
+                return true;
+            }
+
+            if (vPlayer.isAutoUnclaimingEnabled()) {
+                vPlayer.setAutoUnclaimingEnabled(false, false);
+                String message = language.getMessage("command_village_claim_autounclaim_off");
+                message = message.replace("%village%", village.getTownName());
+                commandSender.sendMessage(message);
+            } else {
+                // Disable autoclaim if it is enabled
+                if (vPlayer.isAutoClaimingEnabled()) {
+                    vPlayer.setAutoClaimingEnabled(false, false);
+                }
+                vPlayer.setAutoUnclaimingEnabled(true, false);
+                String message = language.getMessage("command_village_claim_autounclaim_on");
+                message = message.replace("%village%", village.getTownName());
+                commandSender.sendMessage(message);
+            }
+            return true;
+        }
+
+        // Player is unclaiming a single chunk (default)
 
         VChunk vChunk = new VChunk(player.getLocation());
 

--- a/src/main/java/com/johnymuffin/jvillage/beta/config/JVillageLanguage.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/config/JVillageLanguage.java
@@ -126,7 +126,8 @@ public class JVillageLanguage extends Configuration {
                 "\n&8- &7/village claim rectangle [chunk radius] &8- &7Claim a rectangle of chunks" +
                 "\n&8- &7/village claim auto &8- &7Claim chunks automatically as you walk (run again to disable)" +
                 "\n&8- &7/village withdraw [village] [amount] &8- &7Withdraw money from village bank" +
-                "\n&8- &7/village unclaim &8- &7Unclaim the chunk you are standing in");
+                "\n&8- &7/village unclaim &8- &7Unclaim the chunk you are standing in" +
+                "\n&8- &7/village unclaim auto &8- &7Unclaim chunks automatically as you walk");
 
         map.put("command_village_owner_help", "&cJVillage Owner Commands" +
                 "\n&8- &7/village create [name] &8- &7Create a new village" +

--- a/src/main/java/com/johnymuffin/jvillage/beta/config/JVillageLanguage.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/config/JVillageLanguage.java
@@ -234,8 +234,8 @@ public class JVillageLanguage extends Configuration {
         map.put("command_village_unclaim_success", "&bUnclaimed the chunk you are standing in. You have been refunded $%refund%");
         map.put("command_village_unclaim_not_assistant", "&cSorry, you are not an assistant or owner of &9%village%&c so you can't unclaim chunks");
         map.put("command_village_unclaim_spawn_block", "&cSorry, you can't unclaim the chunk that contains the village spawn");
-        map.put("command_village_claim_autounclaim_on", "&bYou have turned on autoclaim. You will now automatically unclaim chunks as you walk around");
-        map.put("command_village_claim_autounclaim_off", "&bYou have turned off autoclaim. You will no longer automatically unclaim chunks as you walk around");
+        map.put("command_village_claim_autounclaim_on", "&bYou have turned on auto unclaim. You will now automatically unclaim chunks as you walk around");
+        map.put("command_village_claim_autounclaim_off", "&bYou have turned off auto unclaim. You will no longer automatically unclaim chunks as you walk around");
 
         map.put("command_village_kick_use", "&cSorry, that is invalid. Try /village kick [name]");
         map.put("command_village_kick_not_found", "&cSorry, the UUID of &9%player% &cwas not found");

--- a/src/main/java/com/johnymuffin/jvillage/beta/config/JVillageLanguage.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/config/JVillageLanguage.java
@@ -234,6 +234,8 @@ public class JVillageLanguage extends Configuration {
         map.put("command_village_unclaim_success", "&bUnclaimed the chunk you are standing in. You have been refunded $%refund%");
         map.put("command_village_unclaim_not_assistant", "&cSorry, you are not an assistant or owner of &9%village%&c so you can't unclaim chunks");
         map.put("command_village_unclaim_spawn_block", "&cSorry, you can't unclaim the chunk that contains the village spawn");
+        map.put("command_village_claim_autounclaim_on", "&bYou have turned on autoclaim. You will now automatically unclaim chunks as you walk around");
+        map.put("command_village_claim_autounclaim_off", "&bYou have turned off autoclaim. You will no longer automatically unclaim chunks as you walk around");
 
         map.put("command_village_kick_use", "&cSorry, that is invalid. Try /village kick [name]");
         map.put("command_village_kick_not_found", "&cSorry, the UUID of &9%player% &cwas not found");
@@ -306,10 +308,12 @@ public class JVillageLanguage extends Configuration {
 
         map.put("autoclaim_selected_village_disabled", "&cSorry, autoclaim has been disabled as your selected village has changed");
         map.put("autoclaim_disabled", "&cAutoclaim has been disabled");
+        map.put("autounclaim_disabled", "&cAuto unclaim has been disabled");
         map.put("autoclaim_enter_worldguard_disabled", "&cSorry, autoclaim has been disabled as you have entered a protected World Guard region");
         map.put("autoclaim_not_neighbouring_disabled", "&cSorry, autoclaim has been disabled as you are not neighbouring %village%");
         map.put("autoclaim_not_enough_money_disabled", "&cSorry, autoclaim has been disabled as you don't have enough money to claim land");
         map.put("autoclaim_claim_success", "&bYou have claimed [%chunk%] for &9%village% &bfor &9$%cost%");
+        map.put("autoclaim_unclaim_success", "&bYou have unclaimed [%chunk%] for &9%village% &bfor a &9$%cost% refund");
 
     }
 

--- a/src/main/java/com/johnymuffin/jvillage/beta/listeners/JVPlayerMoveListener.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/listeners/JVPlayerMoveListener.java
@@ -40,6 +40,7 @@ public class JVPlayerMoveListener extends CustomEventListener implements Listene
         //Disable auto claiming when a player teleports if they have it enabled
         VPlayer vPlayer = plugin.getPlayerMap().getPlayer(event.getPlayer().getUniqueId());
         vPlayer.setAutoClaimingEnabled(false, true);
+        vPlayer.setAutoUnclaimingEnabled(false, true);
     }
 
     @EventHandler(ignoreCancelled = true, priority = Event.Priority.Highest)
@@ -49,6 +50,7 @@ public class JVPlayerMoveListener extends CustomEventListener implements Listene
         //Disable auto claiming when a player respawns if they have it enabled
         VPlayer vPlayer = plugin.getPlayerMap().getPlayer(event.getPlayer().getUniqueId());
         vPlayer.setAutoClaimingEnabled(false, true);
+        vPlayer.setAutoUnclaimingEnabled(false, true);
     }
 
     @EventHandler(ignoreCancelled = true, priority = Event.Priority.Highest)
@@ -58,6 +60,7 @@ public class JVPlayerMoveListener extends CustomEventListener implements Listene
         //Disable auto claiming when a player joins if they have it enabled
         VPlayer vPlayer = plugin.getPlayerMap().getPlayer(event.getPlayer().getUniqueId());
         vPlayer.setAutoClaimingEnabled(false, false); //Don't send message as it shouldn't be enabled anyway
+        vPlayer.setAutoUnclaimingEnabled(false, false);
 
         //Record appropriate player data
         String firstJoin = plugin.getPlayerData().getPlayerData(event.getPlayer().getUniqueId(), "firstJoin");
@@ -77,6 +80,7 @@ public class JVPlayerMoveListener extends CustomEventListener implements Listene
         //Disable auto claiming when a player changes world if they have it enabled
         VPlayer vPlayer = plugin.getPlayerMap().getPlayer(event.getPlayer().getUniqueId());
         vPlayer.setAutoClaimingEnabled(false, true);
+        vPlayer.setAutoUnclaimingEnabled(false, true);
     }
 
     @EventHandler
@@ -84,6 +88,7 @@ public class JVPlayerMoveListener extends CustomEventListener implements Listene
         //Disable auto claiming when a player quits if they have it enabled
         VPlayer vPlayer = plugin.getPlayerMap().getPlayer(event.getPlayer().getUniqueId());
         vPlayer.setAutoClaimingEnabled(false, false);
+        vPlayer.setAutoUnclaimingEnabled(false, false);
 
         plugin.getPlayerData().setPlayerData(event.getPlayer().getUniqueId(), "lastOnline", String.valueOf(System.currentTimeMillis()/1000L));
     }

--- a/src/main/java/com/johnymuffin/jvillage/beta/player/VPlayer.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/player/VPlayer.java
@@ -9,6 +9,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.UUID;
 import java.util.logging.Level;
 
@@ -27,6 +28,8 @@ public class VPlayer {
     private Village selectedVillage = null;
 
     private boolean isAutoClaimingEnabled = false;
+
+    private boolean isAutoUnclaimingEnabled = false;
 
 //    private ArrayList<Village> invitedTo = new ArrayList<>();
 
@@ -269,6 +272,10 @@ public class VPlayer {
         return this.isAutoClaimingEnabled;
     }
 
+    public boolean isAutoUnclaimingEnabled() {
+        return this.isAutoUnclaimingEnabled;
+    }
+
     public void setAutoClaimingEnabled(boolean autoClaimingEnabled, boolean sendMessage) {
         if (this.isAutoClaimingEnabled == autoClaimingEnabled) {
             return;
@@ -278,6 +285,19 @@ public class VPlayer {
         this.isAutoClaimingEnabled = autoClaimingEnabled;
         if (!this.isAutoClaimingEnabled && sendMessage) {
             String message = this.plugin.getLanguage().getMessage("autoclaim_disabled");
+            this.sendMessage(message);
+        }
+    }
+
+    public void setAutoUnclaimingEnabled(boolean autoUnclaimingEnabled, boolean sendMessage) {
+        if (this.isAutoUnclaimingEnabled == autoUnclaimingEnabled) {
+            return;
+        }
+
+
+        this.isAutoUnclaimingEnabled = autoUnclaimingEnabled;
+        if (!this.isAutoUnclaimingEnabled && sendMessage) {
+            String message = this.plugin.getLanguage().getMessage("autounclaim_disabled");
             this.sendMessage(message);
         }
     }

--- a/src/main/java/com/johnymuffin/jvillage/beta/tasks/AutoUnclaimingTask.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/tasks/AutoUnclaimingTask.java
@@ -1,0 +1,112 @@
+package com.johnymuffin.jvillage.beta.tasks;
+
+import com.johnymuffin.jvillage.beta.JVillage;
+import com.johnymuffin.jvillage.beta.config.JVillageLanguage;
+import com.johnymuffin.jvillage.beta.models.VCords;
+import com.johnymuffin.jvillage.beta.models.Village;
+import com.johnymuffin.jvillage.beta.models.chunk.ChunkClaimSettings;
+import com.johnymuffin.jvillage.beta.models.chunk.VChunk;
+import com.johnymuffin.jvillage.beta.models.chunk.VClaim;
+import com.johnymuffin.jvillage.beta.player.VPlayer;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.HashMap;
+import java.util.logging.Level;
+
+import static com.johnymuffin.jvillage.beta.JVUtility.cordsInChunk;
+import static com.johnymuffin.jvillage.beta.JVUtility.getChunkCenter;
+
+public class AutoUnclaimingTask implements Runnable {
+    private JVillage plugin;
+
+    private JVillageLanguage language;
+
+    public AutoUnclaimingTask(JVillage plugin) {
+        this.plugin = plugin;
+        language = this.plugin.getLanguage();
+    }
+
+    @Override
+    public void run() {
+        //For each online player
+        plugin.debugLogger(Level.INFO, "Running auto unclaiming task");
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            VPlayer vPlayer = plugin.getPlayerMap().getPlayer(player.getUniqueId());
+
+            //If auto unclaiming is not enabled, skip
+            if (!vPlayer.isAutoUnclaimingEnabled()) {
+                plugin.debugLogger(Level.INFO, "Player " + player.getName() + " does not have auto unclaiming enabled. Skipping.");
+                continue;
+            }
+
+            if (vPlayer.getSelectedVillage() == null) {
+                //This should never happen but just in case
+                vPlayer.setAutoUnclaimingEnabled(false, true);
+                this.plugin.logger(Level.WARNING, "Player " + player.getName() + " has auto unclaiming enabled but no village selected. Disabling auto unclaiming.");
+                continue;
+            }
+
+            Village village = vPlayer.getSelectedVillage();
+
+            //Check player is at least an assistant in the village
+            if (!village.isAssistant(player.getUniqueId())) {
+                vPlayer.setAutoUnclaimingEnabled(false, true);
+                this.plugin.logger(Level.WARNING, "Player " + player.getName() + " has auto unclaiming enabled but is not an assistant in the village. Disabling auto unclaiming.");
+                continue;
+            }
+
+            // Player is currently located in the wilderness or another village, so can't unclaim
+            if (vPlayer.getCurrentlyLocatedIn() == null || vPlayer.getCurrentlyLocatedIn() != vPlayer.getSelectedVillage()) {
+                continue;
+            }
+
+            VChunk vChunk = new VChunk(player.getLocation());
+
+            if (!this.plugin.worldGuardIsClaimAllowed(getChunkCenter(vChunk))) {
+                plugin.debugLogger(Level.INFO, "Player " + player.getName() + " is trying to unclaim a protected WorldGuard region. Disabling auto unclaiming.");
+                //Claim is protected, disable auto unclaiming, message player and continue
+                vPlayer.setAutoUnclaimingEnabled(false, false);
+                String message = language.getMessage("autoclaim_enter_worldguard_disabled");
+                vPlayer.sendMessage(message);
+                continue;
+            }
+
+            //Check if the chunk is claimed by the village
+            if (!village.isClaimed(vChunk)) {
+                String message = language.getMessage("command_village_unclaim_not_claimed");
+                message = message.replace("%village%", village.getTownName());
+                vPlayer.sendMessage(message);
+                continue;
+            }
+
+            //Block unclaim if the chunk is the spawn chunk
+            VCords spawnCords = village.getTownSpawn();
+
+            if (cordsInChunk(spawnCords, vChunk)) {
+                String message = language.getMessage("command_village_unclaim_spawn_block");
+                vPlayer.sendMessage(message + "\n");
+                vPlayer.setAutoUnclaimingEnabled(false, true);
+                continue;
+            }
+
+            ChunkClaimSettings chunkClaimSettings = village.getChunkClaimSettings(vChunk);
+
+            //Refund the village the cost of the chunk
+            double refund = chunkClaimSettings.getPrice();
+            village.addBalance(refund);
+
+            //Unclaim the chunk
+            village.removeClaim(new VClaim(village, vChunk));
+            String message = language.getMessage("autoclaim_unclaim_success");
+            message = message.replace("%village%", village.getTownName());
+            message = message.replace("%chunk%", vChunk.toString());
+            message = message.replace("%cost%", String.valueOf(refund));
+            vPlayer.sendMessage(message);
+            plugin.logger(Level.INFO, vChunk.toString() + " unclaimed by " + player.getName() + " for " + village.getTownName() + " with a refund of $" + refund);
+
+            // set player location to wilderness in case they unclaim then stand still
+            vPlayer.setCurrentlyLocatedIn(player, null);
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -94,6 +94,7 @@ permissions:
       jvillage.player.spawn: true
       jvillage.player.kick: true
       jvillage.player.unclaim: true
+      jvillage.player.unclaim.auto: true
       jvillage.player.claim: true
       jvillage.player.create: true
       jvillage.player.delete: true


### PR DESCRIPTION
pulled a good chunk from the existing auto claim and modified some of the conditions. Basically, auto unclaim will remain active as long as the player does not leave, teleport, enter world guard protected territories, or try to unclaim the village spawn chunk. Switching from claim to unclaim will disable the other one so only one auto function is active at any given time.