### PR TITLE
Allow village invites to be sent to offline players

### DIFF
--- a/src/main/java/com/johnymuffin/jvillage/beta/commands/JVilageAdminCMD.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/commands/JVilageAdminCMD.java
@@ -298,7 +298,7 @@ public class JVilageAdminCMD extends JVBaseCommand {
 
         if (!village.isMember(target.getUUID())) {
             village.addMember(target.getUUID());
-            village.uninvitePlayer(target.getUUID()); //This is just in case they were invited
+            target.removeInvitationToVillage(village); //This is just in case they were invited
             target.joinVillage(village);
         }
 
@@ -360,7 +360,7 @@ public class JVilageAdminCMD extends JVBaseCommand {
 
         //Add player to village
         village.addMember(target.getUUID());
-        village.uninvitePlayer(target.getUUID()); //This is just in case they were invited
+        target.removeInvitationToVillage(village); //This is just in case they were invited
         target.joinVillage(village);
 
         //Tell the player they have been added to the village

--- a/src/main/java/com/johnymuffin/jvillage/beta/commands/JVillageCMD.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/commands/JVillageCMD.java
@@ -27,7 +27,9 @@ public class JVillageCMD extends JVBaseCommand {
         registerCommand(new JAutoSwitchCommand(plugin), "autoswitch", "switch", "as");
         registerCommand(new JLeaveCommand(plugin), "leave");
         registerCommand(new JInviteCommand(plugin), "invite");
+        registerCommand(new JInvitesCommand(plugin), "invites");
         registerCommand(new JJoinCommand(plugin), "join");
+        registerCommand(new JDenyCommand(plugin), "deny");
         registerCommand(new JDeleteCommand(plugin), "delete");
         registerCommand(new JCreateCommand(plugin), "create");
         registerCommand(new JClaimCommand(plugin), "claim", "c");

--- a/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JDenyCommand.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JDenyCommand.java
@@ -1,0 +1,63 @@
+package com.johnymuffin.jvillage.beta.commands.village;
+
+import com.johnymuffin.jvillage.beta.JVillage;
+import com.johnymuffin.jvillage.beta.commands.JVBaseCommand;
+import com.johnymuffin.jvillage.beta.models.Village;
+import com.johnymuffin.jvillage.beta.player.VPlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class JDenyCommand extends JVBaseCommand implements CommandExecutor {
+
+    public JDenyCommand(JVillage plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender commandSender, Command command, String s, String[] strings) {
+        if (!isAuthorized(commandSender, "jvillage.player.deny")) {
+            commandSender.sendMessage(language.getMessage("no_permission"));
+            return true;
+        }
+
+        if (!(commandSender instanceof Player)) {
+            commandSender.sendMessage(language.getMessage("unavailable_to_console"));
+            return true;
+        }
+
+        Player player = (Player) commandSender;
+        VPlayer vPlayer = plugin.getPlayerMap().getPlayer(player.getUniqueId());
+
+        if (strings.length == 0) {
+            commandSender.sendMessage(language.getMessage("command_village_deny_use"));
+            return true;
+        }
+
+        String villageName = strings[0];
+        Village village = plugin.getVillageMap().getVillage(villageName);
+        if (village == null) {
+            commandSender.sendMessage(language.getMessage("village_not_found"));
+            return true;
+        }
+
+        if (!vPlayer.isInvitedToVillage(village)) {
+            String message = language.getMessage("command_village_deny_denied");
+            message = message.replace("%village%", village.getTownName());
+            commandSender.sendMessage(message);
+            return true;
+        }
+
+        vPlayer.removeInvitationToVillage(village);
+        String message = language.getMessage("command_village_deny_success");
+        message = message.replace("%village%", village.getTownName());
+        commandSender.sendMessage(message);
+
+        String broadcast = language.getMessage("command_village_deny_broadcast");
+        broadcast = broadcast.replace("%player%", player.getName());
+        village.broadcastToTown(broadcast);
+
+        return true;
+    }
+}

--- a/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JInviteCommand.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JInviteCommand.java
@@ -1,14 +1,16 @@
 package com.johnymuffin.jvillage.beta.commands.village;
 
+import com.johnymuffin.jvillage.beta.JVUtility;
 import com.johnymuffin.jvillage.beta.JVillage;
 import com.johnymuffin.jvillage.beta.commands.JVBaseCommand;
 import com.johnymuffin.jvillage.beta.models.Village;
 import com.johnymuffin.jvillage.beta.player.VPlayer;
-import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+
+import java.util.UUID;
 
 public class JInviteCommand extends JVBaseCommand implements CommandExecutor {
 
@@ -39,15 +41,15 @@ public class JInviteCommand extends JVBaseCommand implements CommandExecutor {
 
         if (strings.length > 0) {
             String targetName = strings[0];
-            Player target = Bukkit.getPlayer(targetName);
-            if (target == null) {
+            UUID uuid = JVUtility.getUUIDFromPoseidonCache(targetName);
+            if (uuid == null) {
                 String message = language.getMessage("player_not_found_full");
                 message = message.replace("%username%", targetName);
                 commandSender.sendMessage(message);
                 return true;
             }
 
-            VPlayer vTarget = plugin.getPlayerMap().getPlayer(target.getUniqueId());
+            VPlayer vTarget = plugin.getPlayerMap().getPlayer(uuid);
             if (village.isMember(vTarget.getUUID())) {
                 String message = language.getMessage("command_village_invite_already");
                 message = message.replace("%village%", village.getTownName());
@@ -61,15 +63,17 @@ public class JInviteCommand extends JVBaseCommand implements CommandExecutor {
                 vTarget.inviteToVillage(village);
                 String message = language.getMessage("command_village_invite_sent");
                 message = message.replace("%village%", village.getTownName());
-                message = message.replace("%player%", target.getName());
+                message = message.replace("%player%", vTarget.getUsername());
                 sendWithNewline(commandSender, message);
                 //Message target
-                String targetMessage = language.getMessage("command_village_invite_received");
-                targetMessage = targetMessage.replace("%village%", village.getTownName());
-                sendWithNewline(target, targetMessage);
+                if (vTarget.isPlayerOnline()) {
+                    String targetMessage = language.getMessage("command_village_invite_received");
+                    targetMessage = targetMessage.replace("%village%", village.getTownName());
+                    sendWithNewline(JVUtility.getPlayerFromUUID(vTarget.getUUID()), targetMessage);
+                }
                 //Broadcast
                 String broadcast = language.getMessage("command_village_invite_broadcast");
-                broadcast = broadcast.replace("%player%", target.getName());
+                broadcast = broadcast.replace("%player%", vTarget.getUsername());
                 broadcast = broadcast.replace("%villagemember%", player.getName());
                 village.broadcastToTown(broadcast);
                 return true;

--- a/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JInvitesCommand.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JInvitesCommand.java
@@ -1,0 +1,51 @@
+package com.johnymuffin.jvillage.beta.commands.village;
+
+import com.johnymuffin.jvillage.beta.JVillage;
+import com.johnymuffin.jvillage.beta.commands.JVBaseCommand;
+import com.johnymuffin.jvillage.beta.models.Village;
+import com.johnymuffin.jvillage.beta.player.VPlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+
+public class JInvitesCommand extends JVBaseCommand implements CommandExecutor {
+
+    public JInvitesCommand(JVillage plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender commandSender, Command command, String s, String[] strings) {
+        if (!isAuthorized(commandSender, "jvillage.player.invites")) {
+            commandSender.sendMessage(language.getMessage("no_permission"));
+            return true;
+        }
+
+        if (!(commandSender instanceof Player)) {
+            commandSender.sendMessage(language.getMessage("unavailable_to_console"));
+            return true;
+        }
+
+        Player player = (Player) commandSender;
+        VPlayer vPlayer = plugin.getPlayerMap().getPlayer(player.getUniqueId());
+        ArrayList<Village> invites = vPlayer.getInvitedToVillages();
+
+        if (invites.isEmpty()) {
+            commandSender.sendMessage(language.getMessage("command_village_invites_no_invites"));
+            return true;
+        }
+
+        commandSender.sendMessage(language.getMessage("command_village_invites_pending"));
+        for (Village village : invites) {
+            String message = language.getMessage("command_village_invites_village");
+            message = message.replace("%village%", village.getTownName());
+            commandSender.sendMessage(message);
+        }
+        commandSender.sendMessage(language.getMessage("command_village_invites_invite_use"));
+
+        return true;
+    }
+}

--- a/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JJoinCommand.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/commands/village/JJoinCommand.java
@@ -57,7 +57,7 @@ public class JJoinCommand extends JVBaseCommand implements CommandExecutor {
 
         if (vPlayer.isInvitedToVillage(village)) {
             vPlayer.joinVillage(village);
-            village.uninvitePlayer(vPlayer.getUUID());
+            vPlayer.removeInvitationToVillage(village);
             String message = language.getMessage("command_village_join_success");
             message = message.replace("%village%", village.getTownName());
             commandSender.sendMessage(message);

--- a/src/main/java/com/johnymuffin/jvillage/beta/config/JVillageLanguage.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/config/JVillageLanguage.java
@@ -39,17 +39,17 @@ public class JVillageLanguage extends Configuration {
         map.put("village_owner_leave", "&4Sorry, the owner of a village can't leave it");
         map.put("movement_village_enter", "&bYou have entered the village of &9%village%");
         map.put("movement_wilderness_enter", "&bYou have entered the wilderness");
+        map.put("movement_autoselect_enter", "&bYour selected village has been set to &9%village% &bbecause you have entered it");
         map.put("unknown_economy_error", "&4Sorry, an unknown economy error occurred");
 
         map.put("assistant_or_higher", "&4Sorry, you must be an assistant or higher to do that");
         map.put("owner_or_higher", "&4Sorry, you must be the owner or higher to do that");
 
-
-        map.put("movement_autoselect_enter", "&bYour selected village has been set to &9%village% &bbecause you have entered it");
-
         map.put("build_denied", "&4Sorry, you don't have permission to build in &9%village%");
         map.put("destroy_denied", "&4Sorry, you don't have permission to destroy in &9%village%");
         map.put("ignite_denied", "&4Sorry, you don't have permission to \"ignite\" in &9%village% :(");
+
+        map.put("notification_invites", "&bYou have pending village invites! To view, type &9/village invites");
 
         //JVillage Admin command
         map.put("command_villageadmin_general_use", "&cSorry, that is invalid. Try /villageadmin (plugin|world|village|player)");
@@ -113,7 +113,9 @@ public class JVillageLanguage extends Configuration {
                 "\n&8- &7/village help [&fplayer&7|assistant|owner]&8- &7Shows selected help page" +
                 "\n&8- &7/village select [village] &8- &7Select a village to modify" +
                 "\n&8- &7/village join [village] &8- &7Joins a village" +
+                "\n&8- &7/village deny [village] &8- &7Denies a village invite" +
                 "\n&8- &7/village leave [village]&8- &7Leaves a village" +
+                "\n&8- &7/village invites &8- &7Shows pending village invites" +
                 "\n&8- &7/village autoswitch [on/off] &8- &7Autoswitch town" +
                 "\n&8- &7/village balance [village] &8- &7Shows village balance" +
                 "\n&8- &7/village deposit [village] [amount] &8- &7Deposit money into village bank" +
@@ -189,11 +191,21 @@ public class JVillageLanguage extends Configuration {
         map.put("command_village_invite_sent", "&bYou have invited &9%player% &bto join &9%village%");
         map.put("command_village_invite_broadcast", "&f%player% has been invited by %villagemember%");
 
+        map.put("command_village_invites_pending", "&bPending invites:");
+        map.put("command_village_invites_village", "&7- &9%village%");
+        map.put("command_village_invites_invite_use", "&7/village [join|deny] [village]");
+        map.put("command_village_invites_no_invites", "&cSorry, you have no pending village invites");
+
         map.put("command_village_join_use", "&cSorry, that is invalid. Try /village join [village]");
         map.put("command_village_join_success", "&bYou have joined the village &9%village%");
         map.put("command_village_join_denied", "&cSorry, you haven't received an invite to join %village%");
         map.put("command_village_join_limit", "&cSorry, you can't join %village%. You have reached the limit of %limit% villages");
         map.put("command_village_join_broadcast", "&f%player% has joined the village.");
+
+        map.put("command_village_deny_use", "&cSorry, that is invalid. Try /village deny [village]");
+        map.put("command_village_deny_success", "&bYou have denied the invite to &9%village%");
+        map.put("command_village_deny_denied", "&cSorry, you haven't received an invite to join %village%");
+        map.put("command_village_deny_broadcast", "&f%player% has denied the invite");
 
         map.put("command_village_delete_use", "&cSorry, that is invalid. Try /village delete [village]");
         map.put("command_village_delete_not_owner", "&cSorry, you are not the owner so you can't delete %village%");

--- a/src/main/java/com/johnymuffin/jvillage/beta/listeners/JVPlayerMoveListener.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/listeners/JVPlayerMoveListener.java
@@ -13,6 +13,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.*;
 
+import java.util.ArrayList;
+
 public class JVPlayerMoveListener extends CustomEventListener implements Listener {
     private JVillage plugin;
 
@@ -70,6 +72,11 @@ public class JVPlayerMoveListener extends CustomEventListener implements Listene
         plugin.getPlayerData().setPlayerData(event.getPlayer().getUniqueId(), "username", event.getPlayer().getName());
         plugin.getPlayerData().setPlayerData(event.getPlayer().getUniqueId(), "lastOnline", String.valueOf(System.currentTimeMillis()/1000L));
         plugin.getPlayerData().setUUID(vPlayer.getUsername(), event.getPlayer().getUniqueId());
+
+        ArrayList<Village> invites = vPlayer.getInvitedToVillages();
+        if (!invites.isEmpty()) {
+            event.getPlayer().sendMessage(plugin.getLanguage().getMessage("notification_invites"));
+        }
     }
 
     //TODO: This might not be needed, decide if it is or not

--- a/src/main/java/com/johnymuffin/jvillage/beta/models/Village.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/models/Village.java
@@ -64,7 +64,7 @@ public class Village implements ClaimManager {
         this.townUUID = uuid; // Ignore UUID in JSON file and use the one from the file name
         this.owner = UUID.fromString(String.valueOf(object.get("owner")));
         this.townSpawn = new VSpawnCords((JSONObject) object.get("townSpawn"));
-        JSONObject warps = object.get("warps") != null ? (JSONObject) object.get("warps") : new JSONObject();
+        JSONObject warps = (JSONObject) object.getOrDefault("warps", new JSONObject());
         for (Object warp : warps.keySet()) {
             String warpName = warp.toString();
             VSpawnCords cords = new VSpawnCords((JSONObject) warps.get(warpName));
@@ -79,6 +79,11 @@ public class Village implements ClaimManager {
         for (Object assistant : assistants) {
             this.assistants.add(UUID.fromString(String.valueOf(assistant)));
         }
+        JSONArray invited = (JSONArray) object.getOrDefault("invited", new JSONArray());
+        for (Object invitee : invited) {
+            this.invited.add(UUID.fromString(String.valueOf(invitee)));
+        }
+
         JSONArray claims = (JSONArray) object.get("claims");
         //Loop through worlds
         for (Object claim : claims) {
@@ -188,6 +193,11 @@ public class Village implements ClaimManager {
             assistants.add(assistant.toString());
         }
         object.put("assistants", assistants);
+        JSONArray invited = new JSONArray();
+        for (UUID invitee : this.invited) {
+            invited.add(invitee.toString());
+        }
+        object.put("invited", invited);
         JSONArray claimsJsonArray = new JSONArray();
         for (String worldName : this.getWorldsWithClaims()) {
             JSONArray worldClaims = new JSONArray();

--- a/src/main/java/com/johnymuffin/jvillage/beta/player/VPlayer.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/player/VPlayer.java
@@ -31,7 +31,7 @@ public class VPlayer {
 
     private boolean isAutoUnclaimingEnabled = false;
 
-//    private ArrayList<Village> invitedTo = new ArrayList<>();
+    private ArrayList<Village> invitedTo = new ArrayList<>();
 
     public VPlayer(JVillage plugin, UUID uuid) {
         this.uuid = uuid;
@@ -42,6 +42,8 @@ public class VPlayer {
             Village village = plugin.getVillageMap().getVillage(villageUUID);
             if (village.isMember(uuid)) {
                 memberships.add(village);
+            } else if (village.isInvited(uuid)) {
+                invitedTo.add(village);
             }
         }
         //End - Village Memberships
@@ -110,14 +112,20 @@ public class VPlayer {
 
     public void inviteToVillage(Village village) {
         village.invitePlayer(uuid);
+        invitedTo.add(village);
     }
 
     public boolean isInvitedToVillage(Village village) {
         return village.isInvited(uuid);
     }
 
+    public ArrayList<Village> getInvitedToVillages() {
+        return invitedTo;
+    }
+
     public void removeInvitationToVillage(Village village) {
         village.uninvitePlayer(uuid);
+        invitedTo.remove(village);
     }
 
     public boolean autoSwitchSelected() {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -102,7 +102,9 @@ permissions:
       jvillage.player.create: true
       jvillage.player.delete: true
       jvillage.player.join: true
+      jvillage.player.deny: true
       jvillage.player.invite: true
+      jvillage.player.invites: true
       jvillage.player.leave: true
       jvillage.player.help: true
       jvillage.player.autoswitch: true
@@ -187,8 +189,16 @@ permissions:
     description: Allows access to JVillage player join command
     default: true
 
+  jvillage.player.deny:
+    description: Allows access to JVillage player deny command
+    default: true
+
   jvillage.player.invite:
     description: Allows access to JVillage player invite command
+    default: true
+
+  jvillage.player.invites:
+    description: Allows access to JVillage player invites command
     default: true
 
   jvillage.player.leave:


### PR DESCRIPTION
Changes in this pull request:

- Made it possible to invite offline players to a village
- Added `/village invites` to list currently pending invites
- Added `/village deny` to deny an invite from a village
- Added a notification that shows on join when a player has pending invites